### PR TITLE
Update eksctl config and add cleanup script

### DIFF
--- a/setup/cleanup.sh
+++ b/setup/cleanup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Use helm to remove the demo application yelb
+helm uninstall --namespace yelb-secure yelb-secure
+
+# Use helm to remove the Kube Enforcer
+helm uninstall --namespace aqua aqua-kube-enforcer
+
+# Use helm to remove the Aqua Server
+helm uninstall --namespace aqua aqua-server
+
+# Remove the existing Kubernetes deployments that would prevent a cluster being
+# cleaned up
+kubectl delete --namespace kube-system deployment/ebs-csi-controller
+kubectl delete --namespace kube-system deployment/coredns
+
+# Put a sleep time in place for all of the eks resources to be cleaned up
+echo "Sleeping for 2 minutes while Kubernetes resources are deleted"
+sleep 120
+
+# Remove the EKS Cluster
+eksctl delete cluster -f setup/cluster.yaml

--- a/setup/cluster.yaml
+++ b/setup/cluster.yaml
@@ -6,24 +6,35 @@ kind: ClusterConfig
 metadata:
   name: aquasec-fargatedemo
   region: us-west-1
-  version: "1.27"
+  version: "1.28"
 
 vpc:
   nat:
     gateway: Single # other options: Disable, Single (default)
 
+iam:
+  withOIDC: true
+  serviceAccounts:
+    - metadata:
+        name: ebs-csi-controller-sa
+        namespace: kube-system
+      attachPolicyARNs:
+      - "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+      roleOnly: true
+      roleName: AmazonEKS_EBS_CSI_DriverRole
+
+addons:
+- name: aws-ebs-csi-driver
+  version: latest
+  serviceAccountRoleARN: arn:aws:iam::111222333444:role/AmazonEKS_EBS_CSI_DriverRole
 
 managedNodeGroups:
-  - name: managed-ng-1
-    minSize: 1
-    maxSize: 2
-    desiredCapacity: 1
+  - name: managed-ng
+    minSize: 2
+    maxSize: 4
+    desiredCapacity: 2
     volumeSize: 20
     privateNetworking: true
-    iam:
-      withAddonPolicies:
-        externalDNS: true
-        certManager: true
 
 fargateProfiles:
   - name: yelb-secure

--- a/setup/install_dependencies.sh
+++ b/setup/install_dependencies.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 
 # Install jq
@@ -17,8 +16,3 @@ sudo mv ./kubectl /usr/local/bin/kubectl
 curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 > get_helm.sh
 chmod 700 get_helm.sh
 ./get_helm.sh
-
-# Install Aquactl for linux
-curl --output aquactl https://get.aquasec.com/aquactl/stable/aquactl 
-chmod +x aquactl
-./aquactl version


### PR DESCRIPTION
***Description of changes:***
Updates to the eksctl config file:
- Update to Kubernetes 1.28
- Add the EBS Add On with IRSA configured
- Just bump the number of nodes in the MNG 2

Added a cleanup helper script that can be used to remove the cluster and additional tools.

Aquactl is no longer required as we have switched to helm to install the aqua platform. Therefore removed aquactl from the install dependencies script.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
